### PR TITLE
Replace any text saying "Flappy Bird" and the like with "Flappy Plane"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "flappybird"
 authors = [{name = "Sourabh Verma", email = "email@sourabh.dev"}]
 version = "1.0.0"
-description = "Flappy Bird in Pygame"
+description = "Flappy Plane in Pygame"
 requires-python = ">=3.9,<4"
 dependencies = [
     "pygame == 2.4.0"

--- a/src/flappy.py
+++ b/src/flappy.py
@@ -20,7 +20,7 @@ from .utils import GameConfig, Images, Sounds, Window
 class Flappy:
     def __init__(self):
         pygame.init()
-        pygame.display.set_caption("Flappy Bird")
+        pygame.display.set_caption("Flappy Plane")
         window = Window(288, 512)
         screen = pygame.display.set_mode((window.width, window.height))
         images = Images()
@@ -48,7 +48,7 @@ class Flappy:
             await self.game_over()
 
     async def splash(self):
-        """Shows welcome splash screen animation of flappy bird"""
+        """Shows welcome splash screen animation of flappy plane"""
 
         self.player.set_mode(PlayerMode.SHM)
 

--- a/src/flappyplane.py
+++ b/src/flappyplane.py
@@ -52,7 +52,7 @@ class FlappyPlane:
             await self.game_over()
 
     async def splash(self):
-        """Shows welcome splash screen animation of flappy bird"""
+        """Shows welcome splash screen animation of flappy plane"""
 
         self.player.set_mode(PlayerMode.SHM)
 


### PR DESCRIPTION
I played the game a bit, and then noticed that when running from source, the game displays flappy bird in some places such as the window drag bar instead of flappy plane. I fixed it.